### PR TITLE
Remove all unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 
 use std::fmt;
 use std::ops::{Index, IndexMut};


### PR DESCRIPTION
This makes `BC7_MODE_5_OPTIMAL_ENDPOINTS` and `BC7_MODE_6_OPTIMAL_ENDPOINTS` constants. Their contents are validated by a new unit test which compares their contents to the result from `calculate_mode_8_bc7_tables`.

It also adds `#![forbid(unsafe_code)]` to the crate root to prevent accidental re-introduction of unsafe code.